### PR TITLE
feat!: subclass str for column names - it makes most things easier

### DIFF
--- a/test_streampq.py
+++ b/test_streampq.py
@@ -49,8 +49,8 @@ def test_multiple_queries_with_params_from_iterable(params: Iterable[Tuple[str, 
         )
 
     assert results == (
-        ((('first', 23, -1),), ((1,),)),
-        ((('?column?', 23, -1), ('?column?', 25, -1)), ((2,'3'),)),
+        (('first',), ((1,),)),
+        (('?column?', '?column?'), ((2,'3'),)),
     )
 
 
@@ -66,8 +66,8 @@ def test_multiple_queries(params: Iterable[Tuple[str, str]]) -> None:
         )
 
     assert results == (
-        ((('first', 23, -1),), ((1,),)),
-        ((('?column?', 23, -1), ('?column?', 25, -1)), ((2,'3'),)),
+        (('first',), ((1,),)),
+        (('?column?', '?column?'), ((2,'3'),)),
     )
 
 
@@ -85,7 +85,7 @@ def test_literal_escaping(params: Iterable[Tuple[str, str]]) -> None:
         )
 
     assert results == (
-        ((('first', 25, -1), ('second', 25, -1)),
+        (('first', 'second'),
         (('🍰', 'an\'"other'),)),
     )
 
@@ -105,7 +105,7 @@ def test_identifier_escaping(params: Iterable[Tuple[str, str]]) -> None:
         )
 
     assert results == ((
-        (('🍰', 25, -1), ('an\'"other', 25, -1), ('(1, 2)', 25, -1)),
+        ('🍰', 'an\'"other', '(1, 2)'),
         (('first', 'second', 'third'),)
     ),)
 
@@ -442,7 +442,7 @@ def test_temporary_table(params: Iterable[Tuple[str, str]]) -> None:
 
     assert results == (
         (
-            (('a', 25, -1), ('b', 23, -1)),
+            ('a', 'b'),
             (('foo', 1), ('bar', 2), ('baz', 3)),
         ),
     )
@@ -463,8 +463,8 @@ def test_empty_queries_among_others(params: Iterable[Tuple[str, str]]) -> None:
         )
 
     assert results == (
-        ((('col', 23, -1),), ((1,),)),
-        ((('col', 23, -1),), ((2,),)),
+        (('col',), ((1,),)),
+        (('col',), ((2,),)),
     )
 
 
@@ -480,8 +480,10 @@ def test_with_type_modifier(params: Iterable[Tuple[str, str]]) -> None:
         )
 
     assert results == (
-        ((('col', 1043, 12),), (('a',),)),
+        (('col',), (('a',),)),
     )
+    assert results[0][0][0].type_id == 1043
+    assert results[0][0][0].type_modifier == 12
 
 
 def test_series(params: Iterable[Tuple[str, str]]) -> None:


### PR DESCRIPTION
This is a partial reversion of d0eec6ce065698db0b20111c8c0e7a895f70fc7d. I think it makes it less awkward to access the column names which is the most frequent thing to want to do.